### PR TITLE
add plus.me to OmniAuth initializer

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,7 +3,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2,
     ENV['GOOGLE_CLIENT_ID'],
     ENV['GOOGLE_CLIENT_SECRET'], {
-      access_type: 'offline',
-      scope: 'email, profile, calendar'
+    access_type: 'offline',
+    scope: 'email, profile, plus.me, calendar'
     }
 end


### PR DESCRIPTION
The documentation wasn't totally clear on this
and it would be worth looking into. It states that
if you add your own scopes that you need to re-add
email, and profile. In the code example (which was
not in the README, it listed plus.me as well.

Once this was added the client for the calendar
worked.
